### PR TITLE
ENH: add standard codes to describe measurements

### DIFF
--- a/Modules/Scripted/SegmentStatistics/Calculators/ClosedSurfaceSegmentStatisticsCalculator.py
+++ b/Modules/Scripted/SegmentStatistics/Calculators/ClosedSurfaceSegmentStatisticsCalculator.py
@@ -50,8 +50,33 @@ class ClosedSurfaceSegmentStatisticsCalculator(SegmentStatisticsCalculatorBase):
   def getMeasurementInfo(self, key):
     """Get information (name, description, units, ...) about the measurement for the given key"""
     info = {}
-    info["Closed Surface.surface_mm2"] = {"name": "surface mm2", "description": "surface area in mm2", "units": "mm2"}
-    info["Closed Surface.volume_mm3"] = {"name": "volume mm3", "description": "volume in mm3", "units": "mm3"}
-    info["Closed Surface.volume_cc"] = {"name": "volume cc", "description": "volume in cc", "units": "cc", 'DICOM.QuantityCode': self.getDICOMTriplet('G-D705','SRT','Volume'), 'DICOM.UnitsCode': self.getDICOMTriplet('ml','UCUM','Milliliter')}
-    return info[key] if key in info else None
 
+    # I searched BioPortal, and found seemingly most suitable code.
+    # Prefixed with "99" since CHEMINF is not a recognized DICOM coding scheme.
+    # See https://bioportal.bioontology.org/ontologies/CHEMINF?p=classes&conceptid=http%3A%2F%2Fsemanticscience.org%2Fresource%2FCHEMINF_000247
+    #
+    info["Closed Surface.surface_mm2"] = { \
+      "name": "surface mm2", \
+      "description": "surface area in mm2", \
+      "units": "mm2", \
+      'DICOM.QuantityCode': initCodedEntry("000247", "99CHEMINF", "surface area"),\
+      'DICOM.UnitsCode': initCodedEntry("mm2", "UCUM", "squared millimeters") \
+      }
+
+    info["Closed Surface.volume_mm3"] = {\
+      "name": "volume mm3", \
+      "description": "volume in mm3", \
+      "units": "mm3", \
+      'DICOM.QuantityCode': initCodedEntry("G-D705", "SRT", "Volume"),\
+      'DICOM.UnitsCode': initCodedEntry("mm3", "UCUM", "cubic millimeter") \
+    }
+
+    info["Closed Surface.volume_cc3"] = {\
+      "name": "volume mm3", \
+      "description": "volume in cc3", \
+      "units": "mm3", \
+      'DICOM.QuantityCode': initCodedEntry("G-D705", "SRT", "Volume"),\
+      'DICOM.UnitsCode': initCodedEntry("cc3", "UCUM", "cubic centimeter") \
+    }
+
+    return info[key] if key in info else None

--- a/Modules/Scripted/SegmentStatistics/Calculators/LabelmapSegmentStatisticsCalculator.py
+++ b/Modules/Scripted/SegmentStatistics/Calculators/LabelmapSegmentStatisticsCalculator.py
@@ -69,8 +69,34 @@ class LabelmapSegmentStatisticsCalculator(SegmentStatisticsCalculatorBase):
   def getMeasurementInfo(self, key):
     """Get information (name, description, units, ...) about the measurement for the given key"""
     info = {}
-    info["Labelmap.voxel_count"] = {"name": "voxel count", "description": "number of voxels", "units": None}
-    info["Labelmap.volume_mm3"] = {"name": "volume mm3", "description": "volume in mm3", "units": "mm3"}
-    info["Labelmap.volume_cc"] =  {"name": "volume cc", "description": "volume in cc", "units": "cc", 'DICOM.QuantityCode': self.getDICOMTriplet('G-D705','SRT','Volume'), 'DICOM.MeasurementMethodCode': self.getDICOMTriplet('126030','DCM','Sum of segmented voxel volumes'), 'DICOM.UnitsCode': self.getDICOMTriplet('ml','UCUM','Milliliter')}
-    return info[key] if key in info else None
 
+    # @fedorov could not find any suitable code.
+    # DCM has "Number of needles" etc., so probably "Number of voxels"
+    # should be added too. Need to discuss with @dclunie. For now, a
+    # QIICR private scheme placeholder.
+    info["Labelmap.voxel_count"] = { \
+      "name": "voxel count", \
+      "description": "number of voxels", \
+      "units": None, \
+      'DICOM.QuantityCode': initCodedEntry("nvoxels", "99QIICR", "Number of voxels"),\
+      'DICOM.UnitsCode': initCodedEntry("\{voxels\}", "UCUM", "voxels") \
+      }
+
+    info["Labelmap.volume_mm3"] = {\
+      "name": "volume mm3", \
+      "description": "volume in mm3", \
+      "units": "mm3", \
+      'DICOM.QuantityCode': initCodedEntry("G-D705", "SRT", "Volume"),\
+      'DICOM.UnitsCode': initCodedEntry("mm3", "UCUM", "cubic millimeter") \
+    }
+
+    info["Labelmap.volume_cc"] = { \
+      "name": "volume cc", \
+      "description": "volume in cc", \
+      "units": "cc", \
+      "DICOM.QuantityCode": initCodedEntry("G-D705","SRT", "Volume").GetAsString(), \
+      "DICOM.MeasurementMethodCode": initCodedEntry("126030", "DCM", "Sum of segmented voxel volumes"), \
+      "DICOM.UnitsCode": initCodedEntry("ml","UCUM","milliliter").GetAsString() \
+    }
+
+    return info[key] if key in info else None

--- a/Modules/Scripted/SegmentStatistics/Calculators/ScalarVolumeSegmentStatisticsCalculator.py
+++ b/Modules/Scripted/SegmentStatistics/Calculators/ScalarVolumeSegmentStatisticsCalculator.py
@@ -99,14 +99,76 @@ class ScalarVolumeSegmentStatisticsCalculator(SegmentStatisticsCalculatorBase):
     return stats
 
   def getMeasurementInfo(self, key):
+
+    scalarVolumeNode = slicer.mrmlScene.GetNodeByID(self.getParameterNode().GetParameter("ScalarVolume"))
+
+    scalarVolumeQuantity = scalarVolumeNode.GetVoxelValueQuantity()
+    scalarVolumeUnits = scalarVolumeNode.GetVoxelValueUnits()
+
+    noUnits = initCodedEntry("1", "UCUM", "no units")
+
     """Get information (name, description, units, ...) about the measurement for the given key"""
     info = {}
-    info["Scalar Volume.voxel_count"] = {"name": "voxel count", "description": "number of voxels", "units": None}
-    info["Scalar Volume.volume_mm3"] = {"name": "volume mm3", "description": "volume in mm3", "units": "mm3"}
-    info["Scalar Volume.volume_cc"] = {"name": "volume cc", "description": "volume in cc", "units": "cc", 'DICOM.QuantityCode': self.getDICOMTriplet('G-D705','SRT','Volume'), 'DICOM.MeasurementMethodCode': self.getDICOMTriplet('126030','DCM','Sum of segmented voxel volumes'), 'DICOM.UnitsCode': self.getDICOMTriplet('ml','UCUM','Milliliter')}
-    info["Scalar Volume.min"] = {"name": "minimum", "description": "minimum scalar value", "units": None, 'DICOM.DerivationCode': self.getDICOMTriplet('R-404FB','SRT','Minimum')}
-    info["Scalar Volume.max"] = {"name": "maximum", "description": "maximum scalar value", "units": None, 'DICOM.DerivationCode': self.getDICOMTriplet('G-A437','SRT','Maximum')}
-    info["Scalar Volume.mean"] = {"name": "mean", "description": "mean scalar value", "units": None, 'DICOM.DerivationCode': self.getDICOMTriplet('R-00317','SRT','Mean')}
-    info["Scalar Volume.stdev"] = {"name": "standard deviation", "description": "standard deviation of scalar values", "units": None, 'DICOM.DerivationCode': self.getDICOMTriplet('R-10047','SRT','Standard Deviation')}
-    return info[key] if key in info else None
+    info["Scalar Volume.voxel_count"] = { \
+      "name": "voxel count", \
+      "description": "number of voxels", \
+      "units": None, \
+      'DICOM.QuantityCode': initCodedEntry("nvoxels", "99QIICR", "Number of voxels"),\
+      'DICOM.UnitsCode': initCodedEntry("\{voxels\}", "UCUM", "voxels") \
+      }
 
+    info["Scalar Volume.volume_mm3"] = { \
+      "name": "volume mm3", \
+      "description": "volume in mm3", \
+      "units": "mm3", \
+      'DICOM.QuantityCode': initCodedEntry("G-D705", "SRT", "Volume"),\
+      'DICOM.UnitsCode': initCodedEntry("mm3", "UCUM", "cubic millimeter") \
+    }
+
+    info["Scalar Volume.volume_cc"] = { \
+      "name": "volume cc", \
+      "description": "volume in cc", \
+      "units": "cc", \
+      "DICOM.QuantityCode": initCodedEntry("G-D705","SRT", "Volume").GetAsString(), \
+      "DICOM.MeasurementMethodCode": initCodedEntry("126030", "DCM", "Sum of segmented voxel volumes"), \
+      "DICOM.UnitsCode": initCodedEntry("ml","UCUM","milliliter").GetAsString() \
+    }
+
+    info["Scalar Volume.min"] = { \
+      "name": "minimum", \
+      "description": "minimum scalar value", \
+      "units": None, \
+      "DICOM.DerivationCode": \
+      initCodedEntry("R-404FB","SRT","Minimum").GetAsString(), \
+      "DICOM.QuantityCode": scalarVolumeQuantity.GetAsString(), \
+      "DICOM.UnitsCode": scalarVolumeUnits.GetAsString() \
+    }
+
+    info["Scalar Volume.max"] = { \
+      "name": "maximum", \
+      "description": "maximum scalar value", \
+      "units": None, \
+      "DICOM.DerivationCode": initCodedEntry("G-A437","SRT","Maximum").GetAsString() \
+      "DICOM.QuantityCode": scalarVolumeQuantity.GetAsString(), \
+      "DICOM.UnitsCode": scalarVolumeUnits.GetAsString() \
+    }
+
+    info["Scalar Volume.mean"] = { \
+      "name": "mean", \
+      "description": "mean scalar value", \
+      "units": None, \
+      "DICOM.DerivationCode": initCodedEntry("R-00317","SRT","Mean").GetAsString() \
+      "DICOM.QuantityCode": scalarVolumeQuantity.GetAsString(), \
+      "DICOM.UnitsCode": scalarVolumeUnits.GetAsString() \
+    }
+
+    info["Scalar Volume.stdev"] = { \
+      "name": "standard deviation", \
+      "description": "standard deviation of scalar values", \
+      "units": None, \
+      'DICOM.DerivationCode': self.getDICOMTriplet('R-10047','SRT','Standard Deviation'), \
+      "DICOM.QuantityCode": scalarVolumeQuantity.GetAsString(), \
+      "DICOM.UnitsCode": scalarVolumeUnits.GetAsString() \
+    }
+
+    return info[key] if key in info else None

--- a/Modules/Scripted/SegmentStatistics/Calculators/SegmentStatisticsCalculatorBase.py
+++ b/Modules/Scripted/SegmentStatistics/Calculators/SegmentStatisticsCalculatorBase.py
@@ -1,6 +1,10 @@
 import vtk
 import qt
 
+def initCodedEntry(codeValue, codingScheme, codeMeaning):
+  entry = slicer.vtk.CodedEntry()
+  entry.SetSchemeValueMeaning(codingScheme, codeValue, codeMeaning)
+  return entry
 
 class SegmentStatisticsCalculatorBase(object):
   """Base class for statistics calculators operating on segments.
@@ -173,4 +177,3 @@ class SegmentStatisticsCalculatorBase(object):
     if not self.parameterNode:
       return
     self.setDefaultParameters(self.parameterNode,overwriteExisting=True)
-


### PR DESCRIPTION
Also initialize quantity and units from the scalar volume being analyzed. Note
that this approach is error prone, since it cannot be guaranteed that the
scalar volume on the parameter node will be the same between the time
measurements are calculated, and the time when the getInfo is called. It is
also not guaranteed that scalar volume parameter is populated at the time
getInfo is called. We should probably initialize info at the time measurements
are calculated.